### PR TITLE
zt_opts help callback wrappers / additions

### DIFF
--- a/src/zt_opts.c
+++ b/src/zt_opts.c
@@ -31,8 +31,8 @@
 
 char *
 zt_opt_error_str(int code, char * fmt, ...) {
-    char    * ret;
-    va_list   ap;
+    char  * ret;
+    va_list ap;
 
     va_start(ap, fmt);
     ret = zt_opt_verror_str(code, fmt, ap);
@@ -42,11 +42,11 @@ zt_opt_error_str(int code, char * fmt, ...) {
 
 char *
 zt_opt_verror_str(int code, char * fmt, va_list ap) {
-    char    * msg = NULL;
-    char    * user_message = NULL;
-    char    * final = NULL;
+    char * msg          = NULL;
+    char * user_message = NULL;
+    char * final        = NULL;
 
-    asprintf(&msg, "error: { code: %d, string: \"%s", code, code?strerror(code):"");
+    asprintf(&msg, "error: { code: %d, string: \"%s", code, code ? strerror(code) : "");
     if (fmt) {
         vasprintf(&user_message, fmt, ap);
     }
@@ -59,7 +59,7 @@ zt_opt_verror_str(int code, char * fmt, va_list ap) {
 
 int
 zt_opt_verror_default(int code, char * fmt, va_list ap) {
-    char    * msg = NULL;
+    char * msg = NULL;
 
     if (!code && !fmt) {
         fprintf(stderr, "Invalid call to %s: must set code or format\n", __FUNCTION__);
@@ -71,10 +71,11 @@ zt_opt_verror_default(int code, char * fmt, va_list ap) {
     zt_free(msg);
     return code;
 }
+
 int
 zt_opt_error_default(int code, char * fmt, ...) {
-    int       ret;
-    va_list   ap;
+    int     ret;
+    va_list ap;
 
     va_start(ap, fmt);
     ret = zt_opt_verror_default(code, fmt, ap);
@@ -84,15 +85,15 @@ zt_opt_error_default(int code, char * fmt, ...) {
 }
 
 char *
-zt_opt_get_value(int argn, char **argv, zt_opt_error error) {
-    char    * p = argv[argn];
-    char    * result = argv[argn+1];
+zt_opt_get_value(int argn, char ** argv, zt_opt_error error) {
+    char * p      = argv[argn];
+    char * result = argv[argn + 1];
 
     do {
         if (*p == '=') {
             result = ++p;
         }
-    } while(*p++);
+    } while (*p++);
 
     if (!result) {
         error(EINVAL, "while processing arg '%s'", argv[argn]);
@@ -102,58 +103,59 @@ zt_opt_get_value(int argn, char **argv, zt_opt_error error) {
 }
 
 int
-zt_opt_null(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, zt_opt_error error) { return 0; }
+zt_opt_null(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error) {
+    return 0;
+}
 
 #ifdef HAVE_INTTYPES_H
 int
-zt_opt_intmax(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, zt_opt_error error) {
+zt_opt_intmax(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error) {
+    intmax_t result;
+    char   * end = NULL;
+    char   * arg = zt_opt_get_value(argn, argv, error);
 
-    intmax_t      result;
-    char        * end = NULL;
-    char        * arg = zt_opt_get_value(argn, argv, error);
-
-    errno = 0;
+    errno  = 0;
     result = strtoimax(arg, &end, 0);
 
-    if(errno) {
+    if (errno) {
         /* check errno */
         error(errno, "invalid number '%s'", arg);
     }
 
-    if(end && *end) {
+    if (end && *end) {
         /* invalid character */
         error(EINVAL, "'%s' is not a number", arg);
     }
 
-    if(def[defn].cb_data) {
+    if (def[defn].cb_data) {
         *(intmax_t *)def[defn].cb_data = result;
     }
 
     return 1;
 }
+
 #endif /* HAVE_INTTYPES_H */
 
 int
-zt_opt_long(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, zt_opt_error error) {
+zt_opt_long(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error) {
+    long   result;
+    char * end = NULL;
+    char * arg = zt_opt_get_value(argn, argv, error);
 
-    long          result;
-    char        * end = NULL;
-    char        * arg = zt_opt_get_value(argn, argv, error);
-
-    errno = 0;
+    errno  = 0;
     result = strtol(arg, &end, 0);
 
-    if(errno) {
+    if (errno) {
         /* check errno */
         error(errno, "invalid number '%s'", arg);
     }
 
-    if(end && *end) {
+    if (end && *end) {
         /* invalid character */
         error(EINVAL, "'%s' is not a number", arg);
     }
 
-    if(def[defn].cb_data) {
+    if (def[defn].cb_data) {
         *(long *)def[defn].cb_data = result;
     }
 
@@ -161,11 +163,10 @@ zt_opt_long(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, zt_
 }
 
 int
-zt_opt_bool_int(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, zt_opt_error error) {
-
-    int           result;
-    size_t        len;
-    char        * arg = zt_opt_get_value(argn, argv, error);
+zt_opt_bool_int(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error) {
+    int    result;
+    size_t len;
+    char * arg = zt_opt_get_value(argn, argv, error);
 
     len = strlen(arg);
 
@@ -191,25 +192,24 @@ zt_opt_bool_int(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def,
         if (strcasecmp(arg, "true") == 0 ||
             strcasecmp(arg, "yes") == 0) {
             result = 1;
-        } else if(strcasecmp(arg, "false") == 0 ||
-                  strcasecmp(arg, "no") == 0) {
+        } else if (strcasecmp(arg, "false") == 0 ||
+                   strcasecmp(arg, "no") == 0) {
             result = 0;
         } else {
             error(EINVAL, "'%s' is not a boolean expression", argv[argn]);
         }
     }
 
-    if(def[defn].cb_data) {
+    if (def[defn].cb_data) {
         *(int *)def[defn].cb_data = result;
     }
 
     return 1;
-}
+} /* zt_opt_bool_int */
 
 int
-zt_opt_flag_int(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, zt_opt_error error) {
-
-    if(def[defn].cb_data) {
+zt_opt_flag_int(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error) {
+    if (def[defn].cb_data) {
         *(int *)def[defn].cb_data += 1;
     }
 
@@ -217,8 +217,8 @@ zt_opt_flag_int(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def,
 }
 
 int
-zt_opt_string(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, zt_opt_error error) {
-    char    * arg = zt_opt_get_value(argn, argv, error);
+zt_opt_string(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error) {
+    char * arg = zt_opt_get_value(argn, argv, error);
 
     if (arg) {
         *(char **)def[defn].cb_data = (void *)strdup(arg);
@@ -227,30 +227,54 @@ zt_opt_string(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, z
     return 1;
 }
 
+static int
+_zt_opt_help_stdout_printer(zt_opt_def_t * def) {
+    char   sopt = def->sopt;
+    char * lopt = def->lopt;
+
+    if (sopt != ZT_OPT_NSO || lopt != ZT_OPT_NLO) {
+        int depth = 0;
+
+        depth = printf("   %c%c%c %s%s",
+                       sopt != ZT_OPT_NSO ? '-' : ' ',
+                       sopt != ZT_OPT_NSO ? sopt : ' ',
+                       sopt != ZT_OPT_NSO && lopt != ZT_OPT_NLO ? ',' : ' ',
+                       lopt != ZT_OPT_NLO ? "--" : "  ",
+                       lopt != ZT_OPT_NLO ? lopt : "");
+
+        printf(BLANK "%s\n", INDENT_TO(25, 1, depth), def->help);
+    } else {
+        return -1;
+    }
+
+    return 0;
+}
 
 int
-zt_opt_help_stdout(int argn, int defn, int * argc, char **argv, zt_opt_def_t * def, zt_opt_error error) {
-    int       i;
-    char    * help = def[defn].cb_data;
+zt_opt_help_stdout(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error) {
+    int    i;
+    char * help = def[defn].cb_data;
 
-    printf("usage: %s %s\nOptions:\n", argv[0], help ? help : "");
+    printf("Usage: %s %s\nOptions:\n", argv[0], help ? help : "");
 
-    for(i=0; def[i].cb; i++) {
-        char      sopt = def[i].sopt;
-        char    * lopt = def[i].lopt;
-
-        if (sopt != ZT_OPT_NSO || lopt != ZT_OPT_NLO) {
-            int   depth = 0;
-
-            depth = printf("   %c%c%c %s%s", sopt != ZT_OPT_NSO ? '-' : ' ',
-                                             sopt != ZT_OPT_NSO ? sopt : ' ',
-                                             sopt != ZT_OPT_NSO && lopt != ZT_OPT_NLO ? ',' : ' ',
-                                             lopt != ZT_OPT_NLO ? "--" : "  ",
-                                             lopt != ZT_OPT_NLO ? lopt : "");
-
-            printf(BLANK "%s\n", INDENT_TO(25, 1, depth), def[i].help);
-        } else {
+    for (i = 0; def[i].cb; i++) {
+        if (_zt_opt_help_stdout_printer(&def[i]) < 0) {
             error(0, "Programmer Error: must have a short or long opt at least", NULL);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+int
+zt_opt_usage(const char * name, const char * help, zt_opt_def_t * opts) {
+    int i;
+
+    printf("Usage: %s %s\nOptions:\n", name, help ? help : "");
+
+    for (i = 0; opts[i].cb != NULL; i++) {
+        if (_zt_opt_help_stdout_printer(&opts[i]) < 0) {
             return -1;
         }
     }
@@ -260,10 +284,10 @@ zt_opt_help_stdout(int argn, int defn, int * argc, char **argv, zt_opt_def_t * d
 
 void
 zt_opt_validate_default(zt_opt_def_t * args, zt_opt_error error) {
-    int   i;
-    int   x;
+    int i;
+    int x;
 
-    for(i=0; args[i].cb; i++) {
+    for (i = 0; args[i].cb; i++) {
         if (args[i].sopt == ZT_OPT_NSO && args[i].lopt == ZT_OPT_NLO) {
             error(EINVAL, "Invalid argdef initialization #%d (must include at least one of short opt or long opt)", i);
         }
@@ -280,7 +304,7 @@ zt_opt_validate_default(zt_opt_def_t * args, zt_opt_error error) {
         }
 
         /* slow and does extra work but functional */
-        for(x=0; args[x].cb; x++) {
+        for (x = 0; args[x].cb; x++) {
             if (x == i) {
                 continue;
             }
@@ -298,8 +322,8 @@ zt_opt_validate_default(zt_opt_def_t * args, zt_opt_error error) {
 
 static int
 _zt_opt_error_wrapper(int code, char * fmt, ...) {
-    int       ret;
-    va_list   ap;
+    int     ret;
+    va_list ap;
 
     va_start(ap, fmt);
     ret = zt_opt_verror_default(code, fmt, ap);
@@ -312,40 +336,42 @@ _zt_opt_error_wrapper(int code, char * fmt, ...) {
 }
 
 int
-zt_opt_process_args(int * argc, char **argv, zt_opt_def_t * args, zt_opt_validate validate, zt_opt_error error) {
-    int       i;
+zt_opt_process_args(int * argc, char ** argv, zt_opt_def_t * args, zt_opt_validate validate, zt_opt_error error) {
+    int i;
 
-    error = error ? error : _zt_opt_error_wrapper;
+    error    = error ? error : _zt_opt_error_wrapper;
     validate = validate ? validate : zt_opt_validate_default;
 
     validate(args, error);
 
-    for(i=1; i<*argc; i++) {
-        if(argv[i][0] == '-') {
-            unsigned int      x;
-            size_t            len = 0;
-            char            * p = &argv[i][1];
-            int               combined_opt = 0;
-            int               found = 0;
+    for (i = 1; i < *argc; i++) {
+        if (argv[i][0] == '-') {
+            unsigned int x;
+            size_t       len          = 0;
+            char       * p            = &argv[i][1];
+            int          combined_opt = 0;
+            int          found        = 0;
 
-            if(*p == '-') { /* long opt */
+            if (*p == '-') { /* long opt */
                 ++p;
-                for(len=0; p[len] != '\0' && p[len] != '='; len++);
+                for (len = 0; p[len] != '\0' && p[len] != '='; len++) {
+                    ;
+                }
 
                 if (p[len] == '=') {
                     combined_opt = 1;
                 }
             }
 
-            for(x=0; args[x].cb; x++) {
+            for (x = 0; args[x].cb; x++) {
                 if ((len == 0 && args[x].sopt != ZT_OPT_NSO && *p == args[x].sopt) || /* short opt */
                     /* long opt */
                     (args[x].lopt != ZT_OPT_NLO && strlen(args[x].lopt) == len &&
                      strncmp(p, args[x].lopt, len) == 0)) {
-                    int   ret = 0;
+                    int ret = 0;
 
                     found = 1;
-                    if((ret = args[x].cb(i, x, argc, argv, args, error)) < 0) {
+                    if ((ret = args[x].cb(i, x, argc, argv, args, error)) < 0) {
                         /* error */
                         return ret;
                     }
@@ -357,10 +383,9 @@ zt_opt_process_args(int * argc, char **argv, zt_opt_def_t * args, zt_opt_validat
                 }
             }
 
-            if(!found) {
-                error(EINVAL, "'%.*s'", len?len:1, p);
+            if (!found) {
+                error(EINVAL, "'%.*s'", len ? len : 1, p);
             }
-
         } else {
             break;
         }
@@ -369,4 +394,5 @@ zt_opt_process_args(int * argc, char **argv, zt_opt_def_t * args, zt_opt_validat
     *argc = i;
 
     return 0;
-}
+} /* zt_opt_process_args */
+

--- a/src/zt_opts.h
+++ b/src/zt_opts.h
@@ -19,7 +19,7 @@ BEGIN_C_DECLS
 
 #define ZT_OPT_NSO -1
 #define ZT_OPT_NLO NULL
-#define ZT_OPT_END()  0, NULL, NULL, NULL, NULL
+#define ZT_OPT_END() 0, NULL, NULL, NULL, NULL
 
 typedef int (*zt_opt_error)(int code, char * fmt, ...);
 typedef struct zt_opt_def zt_opt_def_t;
@@ -46,6 +46,7 @@ int    zt_opt_bool_int(int argn, int defn, int * argc, char ** argv, zt_opt_def_
 int    zt_opt_string(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error);
 
 int    zt_opt_help_stdout(int argn, int defn, int * argc, char ** argv, zt_opt_def_t * def, zt_opt_error error);
+int    zt_opt_usage(const char * name, const char * help, zt_opt_def_t * opts);
 
 char * zt_opt_get_value(int argn, char ** argv, zt_opt_error error);
 


### PR DESCRIPTION
- zt_opts_help_stdout will call _zt_opt_help_stdout_printer for each
  argument for arg specific information.
- Added function zt_opt_usage() which calls _help_stdout_printer, the point
  of which is that it can be called manually in leiu of being an argument
  parsers callback.
